### PR TITLE
Changes to purge secret and check v1 provider status.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -348,3 +348,4 @@ MigrationLog*/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+MigrationScript/LogFiles/*

--- a/MigrationScript/AmsOperationsHelper.ps1
+++ b/MigrationScript/AmsOperationsHelper.ps1
@@ -1,9 +1,6 @@
 # ########### Header ###########
 # Refer common library file
 . $PSScriptRoot\ConsoleLogger.ps1
-. $PSScriptRoot\UtilityFunctions.ps1
-. $PSScriptRoot\KeyvaultHelperFunctions.ps1
-. $PSScriptRoot\Constants.ps1
 # #############################
 
 <#
@@ -41,6 +38,7 @@ $requestObj = @{
 					}
 				}
 			}
+. $PSScriptRoot\ConsoleLogger.ps1
 $logger = New-Object ConsoleLogger
 PutAmsV2Provider -subscriptionId $subscriptionId -resourceGroup $resourceGroupName -monitorName $monitorName -request $requestObj -logger $logger;
 #>
@@ -71,7 +69,7 @@ function PutAmsV2Provider([string]$subscriptionId, [string]$resourceGroup, [stri
     catch
     {
         $putErrorMsg = $_.ErrorDetails | ConvertTo-Json -Depth 10;
-		$logger.LogError("Put-AmsV2Provider : Failed with error: ($($putErrorMsg))", "", "");
+		$logger.LogInfo("Put-AmsV2Provider: ($($putErrorMsg))");
     }
 
 	return @{
@@ -100,6 +98,7 @@ Provider name.
 logger object. 
 
 .EXAMPLE
+. $PSScriptRoot\ConsoleLogger.ps1
 $logger = New-Object ConsoleLogger
 GetAmsV2ProviderStatus -subscriptionId $subscriptionId -resourceGroup $resourceGroupName -monitorName $monitorName -providerName $providerName -logger $logger;
 #>
@@ -158,13 +157,14 @@ AMS v2 Monitor Name.
 logger object. 
 
 .EXAMPLE
+. $PSScriptRoot\ConsoleLogger.ps1
 $logger = New-Object ConsoleLogger
 GetAmsV2MonitorProperties -subscriptionId $subscriptionId -resourceGroup $resourceGroupName -monitorName $monitorName -logger $logger
 #>
 function GetAmsV2MonitorProperties([string]$subscriptionId, [string]$resourceGroup, [string]$monitorName, $logger)
 {
-    $rawToken = Get-AzAccessToken -ResourceTypeName Arm
-    $armToken = $rawToken.Token
+    $rawToken = Get-AzAccessToken -ResourceTypeName Arm;
+    $armToken = $rawToken.Token;
 	$v2ApiVersion = "2021-12-01-preview";
 
     $headers = @{
@@ -178,25 +178,25 @@ function GetAmsV2MonitorProperties([string]$subscriptionId, [string]$resourceGro
 	[string]$providerParams = "/providers/Microsoft.Workloads/monitors/" + $monitorName + "?api-version=" + $v2ApiVersion;
 	$url = $url + $subscriptionParams + $rgParams + $providerParams;
 	[string]$provisiongState = "";
-	$logger.LogInfo("Making Get Monitor call with $url")
+	$logger.LogInfo("Making Get Monitor call with $url");
     
 	try
     {
         $response = Invoke-RestMethod -Method 'get' -Uri $url -Headers $headers;
-		$provisiongState = $response.properties.provisioningState
+		$provisiongState = $response.properties.provisioningState;
     }
     catch
     {
         $GetProviderErrorMsg = $_.ErrorDetails.ToString();
-		$logger.LogError("GetAmsV2MonitorProperties : Failed with error: ($($GetProviderErrorMsg.error.code)))", "500", "");
-		$provisiongState = "Not Created"
+		$logger.LogInfo("GetAmsV2MonitorProperties : ($($GetProviderErrorMsg.error.code)))");
+		$provisiongState = "Not Created";
     }
 
 	return @{
 		Response = $response
 		provisiongState = $provisiongState
 		Error = $GetProviderErrorMsg
-	}
+	};
 }
 
 <#
@@ -216,6 +216,7 @@ AMS v2 Monitor Name.
 logger object. 
 
 .EXAMPLE
+. $PSScriptRoot\ConsoleLogger.ps1
 $logger = New-Object ConsoleLogger
 GetAmsV2ManagedKv -subscriptionId $subscriptionId -resourceGroup $resourceGroupName -monitorName $monitorName -logger $logger;
 #>
@@ -238,10 +239,7 @@ function GetAmsV2ManagedKv([string]$subscriptionId, [string]$resourceGroup, [str
 		$logger.LogError("GetAmsV2ManagedKv : Failed with error: ($($GetProviderErrorMsg.error.code)))", "500", "");
     }
 
-	return @{
-		Response = $managedKvName
-		Error = $GetProviderErrorMsg
-	}
+	return $managedKvName;
 }
 
 <#
@@ -264,6 +262,7 @@ Provider Type.
 logger object. 
 
 .EXAMPLE
+. $PSScriptRoot\ConsoleLogger.ps1
 $logger = New-Object ConsoleLogger
 GetAmsV2ManagedFunc -subscriptionId $subscriptionId -resourceGroup $resourceGroupName -monitorName $monitorName -logger $logger;
 #>
@@ -276,7 +275,7 @@ function GetAmsV2ManagedFunc([string]$subscriptionId, [string]$resourceGroup, [s
 		$managedRgName = $response.Response.properties.managedResourceGroupConfiguration.name;
 		$logger.LogInfo("Managed RG Name associated with Monitor : $monitorName is $managedRgName");
 
-		$funcDetails = Get-AzResource -ResourceGroupName $managedRgName -Name "$providerName*" -ResourceType Microsoft.Web/sites
+		$funcDetails = Get-AzResource -ResourceGroupName $managedRgName -Name "$providerType*" -ResourceType Microsoft.Web/sites
 		$logger.LogInfo("Function app for Provider $providerName with Monitor : $monitorName is $($funcDetails.Name)");
 		$managedFuncName = $funcDetails.Name;
     }
@@ -286,8 +285,63 @@ function GetAmsV2ManagedFunc([string]$subscriptionId, [string]$resourceGroup, [s
 		$logger.LogError("GetAmsV2ManagedKv : Failed with error: ($($GetProviderErrorMsg.error.code)))", "500", "");
     }
 
-	return @{
-		Response = $managedFuncName
-		Error = $GetProviderErrorMsg
-	}
+	return $managedFuncName;
+}
+
+
+<#
+.SYNOPSIS
+Function to get the deployment status for Provider.
+
+.PARAMETER subscriptionId
+SubscriptionId of the AMS v1 Monitor.
+
+.PARAMETER resourceGroup
+Resource Group Name of the AMS v1 Monitor.
+
+.PARAMETER monitorName
+AMS v1 Monitor Name.
+
+.PARAMETER providerName
+Provider name.
+
+.PARAMETER logger
+logger object. 
+
+.EXAMPLE
+. $PSScriptRoot\ConsoleLogger.ps1
+$logger = New-Object ConsoleLogger
+GetAmsV1ProviderStatus -subscriptionId $subscriptionId -resourceGroup $resourceGroupName -monitorName $monitorName -providerName $providerName -logger $logger;
+#>
+function GetAmsV1ProviderStatus([string]$subscriptionId, [string]$resourceGroup, [string]$monitorName, [string]$providerName, $logger)
+{
+    $rawToken = Get-AzAccessToken -ResourceTypeName Arm
+    $armToken = $rawToken.Token
+	$v2ApiVersion = "2020-02-07-preview";
+
+    $headers = @{
+        "Content-Type" = "application/json"
+        "Authorization" = "Bearer $armToken"
+    }
+
+    [string]$url = $url = "https://management.azure.com/"
+	[string]$subscriptionParams = "subscriptions/" + $subscriptionId;
+	[string]$rgParams = "/resourceGroups/" + $resourceGroup;
+	[string]$providerParams = "/providers/Microsoft.HanaOnAzure/sapMonitors/" + $monitorName + "/providerInstances/" + $providerName + "?api-version=" + $v2ApiVersion;
+	$url = $url + $subscriptionParams + $rgParams + $providerParams;
+	[string]$provisiongState = "";
+	$logger.LogInfo("Making Get Provider call with $url")
+    
+	try
+    {
+        $response = Invoke-RestMethod -Method 'get' -Uri $url -Headers $headers;
+		[string]$provisiongState = $response.properties.provisioningState
+    }
+    catch
+    {
+        $GetProviderErrorMsg = $_.ErrorDetails.ToString();
+		$logger.LogError("GetAmsV2ProviderStatus : Failed with error: ($($GetProviderErrorMsg)))", "500", "");
+		[string]$provisiongState = "Not Created"
+    }
+	return $provisiongState;
 }

--- a/MigrationScript/AmsOperationsHelper.ps1
+++ b/MigrationScript/AmsOperationsHelper.ps1
@@ -340,7 +340,7 @@ function GetAmsV1ProviderStatus([string]$subscriptionId, [string]$resourceGroup,
     catch
     {
         $GetProviderErrorMsg = $_.ErrorDetails.ToString();
-		$logger.LogError("GetAmsV2ProviderStatus : Failed with error: ($($GetProviderErrorMsg)))", "500", "");
+		$logger.LogInfo("GetAmsV2ProviderStatus : ($($GetProviderErrorMsg)))");
 		[string]$provisiongState = "Not Created"
     }
 	return $provisiongState;

--- a/MigrationScript/AmsOperationsHelper.ps1
+++ b/MigrationScript/AmsOperationsHelper.ps1
@@ -129,7 +129,7 @@ function GetAmsV2ProviderStatus([string]$subscriptionId, [string]$resourceGroup,
     catch
     {
         $GetProviderErrorMsg = $_.ErrorDetails.ToString();
-		$logger.LogError("GetAmsV2ProviderStatus : Failed with error: ($($GetProviderErrorMsg)))", "500", "");
+		$logger.LogInfo("GetAmsV2ProviderStatus : $($GetProviderErrorMsg)");
 		$provisiongState = "Not Created"
     }
 
@@ -340,7 +340,7 @@ function GetAmsV1ProviderStatus([string]$subscriptionId, [string]$resourceGroup,
     catch
     {
         $GetProviderErrorMsg = $_.ErrorDetails.ToString();
-		$logger.LogInfo("GetAmsV2ProviderStatus : ($($GetProviderErrorMsg)))");
+		$logger.LogInfo("GetAmsV1ProviderStatus : $($GetProviderErrorMsg)");
 		[string]$provisiongState = "Not Created"
     }
 	return $provisiongState;

--- a/MigrationScript/AmsOperationsHelper.ps1
+++ b/MigrationScript/AmsOperationsHelper.ps1
@@ -330,18 +330,18 @@ function GetAmsV1ProviderStatus([string]$subscriptionId, [string]$resourceGroup,
 	[string]$providerParams = "/providers/Microsoft.HanaOnAzure/sapMonitors/" + $monitorName + "/providerInstances/" + $providerName + "?api-version=" + $v2ApiVersion;
 	$url = $url + $subscriptionParams + $rgParams + $providerParams;
 	[string]$provisiongState = "";
-	$logger.LogInfo("Making Get Provider call with $url")
+	$logger.LogInfo("Making Get Provider call with $url");
     
 	try
     {
         $response = Invoke-RestMethod -Method 'get' -Uri $url -Headers $headers;
-		[string]$provisiongState = $response.properties.provisioningState
+		[string]$provisiongState = $response.properties.provisioningState;
     }
     catch
     {
         $GetProviderErrorMsg = $_.ErrorDetails.ToString();
 		$logger.LogInfo("GetAmsV1ProviderStatus : $($GetProviderErrorMsg)");
-		[string]$provisiongState = "Not Created"
+		[string]$provisiongState = "Not Created";
     }
 	return $provisiongState;
 }

--- a/MigrationScript/ConsoleLogger.ps1
+++ b/MigrationScript/ConsoleLogger.ps1
@@ -1,14 +1,11 @@
 ﻿Class ConsoleLogger
 {
     [void] LogInfo([string]$message){
-        Write-Host
-        Write-Host
         $date = Get-Date -Format "MM/dd/yyyy HH:mm:ss"
         Write-Host $date " [INFO]" $message
     }
 
     [void] LogInfoObject([string]$message, [Object]$object){
-        Write-Host
         Write-Host
         $serialized = $object | ConvertTo-Json -Depth 10
         $date = Get-Date -Format "MM/dd/yyyy HH:mm:ss"
@@ -17,13 +14,11 @@
 
     [void] LogWarning([string]$message){
         Write-Host
-        Write-Host
         $date = Get-Date -Format "MM/dd/yyyy HH:mm:ss"
         Write-Warning -ForegroundColor Yellow $date " [WARN]" $message
     }
 
     [void] LogError($message, $errorId, $recommendedAction){
-        Write-Host
         Write-Host
         $date = Get-Date -Format "MM/dd/yyyy HH:mm:ss"
         $message = "[ERROR] " + "Message : " + $message + ", ErrorId : " + $errorId + ", Recommended Action : " + $recommendedAction

--- a/MigrationScript/Migration.ps1
+++ b/MigrationScript/Migration.ps1
@@ -1,18 +1,18 @@
 ﻿param(
 #[Parameter(Mandatory=$true)]
-[string]$subscriptionId = "<subscription_id>",
+[string]$subscriptionId = "49d64d54-e966-4c46-a868-1999802b762c",
 
 #[Parameter(Mandatory=$true)]
-[string]$tenantId = "<tenant_id>",
+[string]$tenantId = "72f988bf-86f1-41af-91ab-2d7cd011db47",
 
 #[Parameter(Mandatory=$true)]
-[string]$providerType = $null,
+[string]$providerType = "saphana",
 
 #[Parameter(Mandatory=$true)]
-[string]$amsv1ArmId = "<amsv1-arm-id>",
+[string]$amsv1ArmId = "/subscriptions/49d64d54-e966-4c46-a868-1999802b762c/resourceGroups/rg-ams-migration-test/providers/Microsoft.HanaOnAzure/sapMonitors/ams-v1-migration-hana",
 
 #[Parameter(Mandatory=$true)]
-[string]$amsv2ArmId = "amsv2-arm-id"
+[string]$amsv2ArmId = "/subscriptions/49d64d54-e966-4c46-a868-1999802b762c/resourceGroups/rg-ams-migration-test/providers/Microsoft.Workloads/monitors/ams-migration-test"
 )
 
 # ########### Header ###########
@@ -25,14 +25,27 @@
 . $PSScriptRoot\Constants.ps1
 # #############################
 
-function Get-Token($typeToken)
-{
-    $rawToken = Get-AzAccessToken -ResourceTypeName KeyVault
-    $token = $rawToken.Token
+<#
+.SYNOPSIS
+Function to fetch jwt token for key vault.
 
+.PARAMETER typeToken
+keyvault token.
+
+.EXAMPLE
+Get-Token("KeyVault")
+#>
+function Get-Token([string]$typeToken)
+{
+    $rawToken = Get-AzAccessToken -ResourceTypeName $typeToken;
+    $token = $rawToken.Token;
     return $token
 }
 
+<#
+.SYNOPSIS
+Main Entry Function for migration.
+#>
 function Main
 {
     $global:ENABLE_TRACE = $true
@@ -42,10 +55,12 @@ function Main
 	# Install the pre-requisite modules
 	InstallModules
 
-    $date = Get-Date -Format "MM/dd/yyyy HH:mm:ss"
+    $date = Get-Date -Format "MM-dd-yyyy HH:mm:ss"
+	$shortDate = Get-Date -Format "MM-dd-yyyy"
+	$shortDate = $shortDate.ToString().Replace(":", "-").Replace(" ", "T");
     $dateStr= $date.ToString().Replace(":", "-").Replace(" ", "T")
     $fileName = "MigrationLog_" + $dateStr
-    $logFilePath = Join-Path $PSScriptRoot "\$fileName.txt"
+    $logFilePath = Join-Path $PSScriptRoot "\LogFiles\$shortDate\$fileName.txt";
     Start-Transcript -Path $logFilePath
 
     $logger.LogInfo("-----------Starting migration to AMSv2--------------")
@@ -55,29 +70,38 @@ function Main
         $providerType = Check-ProviderTypeInput
     }
 
-    #Comment the line below if not running on local PowerShell
-	$logger.LogInfo("Please select an account to connect to Azure Portal...")
+    $logger.LogInfo("Please select an account to connect to Azure Portal...")
     Connect-AzAccount
 
     $parsedv1ArmId = Get-ParsedArmId $amsv1ArmId
     $logger.LogInfoObject("Parsed AMSv1 ARM id - ", $parsedv1ArmId)
 
-    Set-CurrentContext $parsedv1ArmId.subscriptionId $tenantId
+    Set-CurrentContext $parsedv1ArmId.subscriptionId $tenantId -logger $logger;
 
+	$logger.LogInfo("Generating JWT token to access keyvault.");
     $KeyVaultToken = Get-Token("KeyVault")
 
     #Generate the KeyVault Name
+	$logger.LogInfo("Generating key vault name using ams v1 armid.");
     $keyVaultName = Get-KeyVaultName $amsv1ArmId
 
     # Add role assignment to read secrets from KeyVault
-    Add-KeyVaultRoleAssignment $keyVaultName
+    Add-KeyVaultRoleAssignment -keyVaultName $keyVaultName -logger $logger;
 
     # Fetch all the secrets from KeyVault
-    $listOfSecrets = Get-AllKeyVaultSecrets $KeyVaultToken $keyVaultName
+	$logger.LogInfo("Fetch all the secrets from Key Vault $keyVaultName.");
+    $listOfSecrets = Get-AllKeyVaultSecrets -KeyVaultToken $KeyVaultToken -keyVaultName $keyVaultName
 
     $saphanaTransformedList = New-Object System.Collections.ArrayList
     $sapNetWeaverTransformedList = New-Object System.Collections.ArrayList
     $unsupportedProviderList = New-Object System.Collections.ArrayList
+
+	if($providerType -notlike "saphana" -and $providerType -notlike "all" -and $providerType -notlike "sapnetweaver") {
+		$logger.LogError(
+			"Provider Type from Parameters $providerType is currently not supported", 
+			"500", 
+			"Accepted values for Provider Type parameter are saphana, sapnetweaver, all");
+	}
 
     foreach ($i in $listOfSecrets.value)
     {
@@ -86,50 +110,51 @@ function Main
             continue
         }
 
-        $secret = Get-SecretValue $i.id
+        $secret = Get-SecretValue -uri $i.id -keyVaultToken $KeyVaultToken
 
         if ($secret.type -like "saphana" -and ($providerType -like "saphana" -or $providerType -like "all"))
         {
-				# if the hana provider is using key vault to fetch user credentials, skip the migration. 
-				# (To be handled later, once the feature is enabled in ams v2)
-               if(!$secret.properties.hanaDbPasswordKeyVaultUrl)
-               {                    
-					$logger.LogInfoObject("Trying to migrate SapHana Provider", $secret.name);
-					$hanaMigrationResult = MigrateHanaProvider -secretName $secret.name -secretValue $secret -logger $logger
+			# if the hana provider is using key vault to fetch user credentials, skip the migration. 
+			# (To be handled later, once the feature is enabled in ams v2)
+			if(!$secret.properties.hanaDbPasswordKeyVaultUrl)
+			{                  
+				$logger.LogInfoObject("Trying to migrate SapHana Provider", $secret.name);
+				$hanaMigrationResult = MigrateHanaProvider -secretName $secret.name -secretValue $secret -logger $logger
 
-					$requestHana = @{
-                        name = $secret.name
-                        type = $secret.type
-						state = $hanaMigrationResult.provisiongState
-                    }
+				$requestHana = @{
+					name = $secret.name
+					type = $secret.type
+					state = $hanaMigrationResult.provisiongState
+				}
 
-					if($hanaMigrationResult.provisiongState -eq "Succeeded"){
-						$logger.LogInfoObject("Adding the following transformed SapHana object to migration list", $requestHana)
-				   	}
+				if($hanaMigrationResult.provisiongState -eq "Succeeded"){
+					$logger.LogInfoObject("Adding the following transformed SapHana object to migration list", $requestHana)
+				}
 
-                    $saphanaTransformedList.Add($requestHana) | Out-Null
-               }
-               else
-               {
-                    $request = @{
-                        name = $secret.name
-                        type = $secret.type
-						state = "Unsupported"
-                    }
-					
-                    $unsupportedProviderList.Add($request) | Out-Null
-                    $logger.LogError("Unsupported Type - SapHana Integrated KeyVault",
-						"100",
-						"Please wait for the support to be enabled in AMSv2 to migrate provider - " + $secret.name)                  
-               }
+				$saphanaTransformedList.Add($requestHana) | Out-Null
+			}
+			else
+			{
+				$request = @{
+					name = $secret.name
+					type = $secret.type
+					state = "Unsupported"
+				}
+				
+				$unsupportedProviderList.Add($request) | Out-Null
+				$logger.LogError("Unsupported Type - SapHana Integrated KeyVault",
+					"100",
+					"Please wait for the support to be enabled in AMSv2 to migrate provider - " + $secret.name)                  
+			}
         }
         elseif($secret.type -like "sapnetweaver" -and ($providerType -like "sapnetweaver" -or $providerType -like "all"))
         {
             # if the netweaver provider is using key vault to fetch user credentials, skip the migration. 
+			# and if the provider is a RFC SAP Netweaver provider then skip the migration. 
 			# (To be handled later, once the feature is enabled in ams v2)
-            if(!$secret.properties.sapPasswordKeyVaultUrl)
+            if(!$secret.properties.sapPasswordKeyVaultUrl -and !$secret.properties.sapRfcSdkBlobUrl)
             {
-				$hashTable = ParseSapNetWeaverHostfile -fileName "hosts.json"
+				$hashTable = ParseSapNetWeaverHostfile -fileName "hosts.json" -logger $logger;
 
                 $logger.LogInfoObject("Trying to migrate SapNetWeaver Provider", $secret.name);
 				$netweaverMigrationResult = MigrateNetWeaverProvider -secretName $secret.name -secretValue $secret -hostfile $hashTable[$secret.name] -logger $logger
@@ -155,7 +180,7 @@ function Main
                     }
 					
                     $unsupportedProviderList.Add($request) | Out-Null
-                    $logger.LogError("Unsupported Type - SapNetweaver Integrated KeyVault",
+                    $logger.LogError("Unsupported Type - SapNetweaver Integrated KeyVault or RFC",
 						"101",
 						"Please wait for the support to be enabled in AMSv2 to migrate provider - " + $secret.name)                  
                }
@@ -187,8 +212,32 @@ function Main
     $logger.LogInfoObject("Not Migrated AMSv1 Unsupported Provider list - ", $unsupportedProviderList)
 
 	$logger.LogInfo("-----------Finishing migration to AMSv2--------------")
-
     Stop-Transcript
+}
+
+<#
+.SYNOPSIS
+Function get the Provider state in AMS v1
+
+.PARAMETER providerName
+Provider Name 
+
+.EXAMPLE
+GetProviderV1ProvisioningState -providerName $providerName;
+#>
+function GetProviderV1ProvisioningState([string]$providerName, $logger) {
+	# checking provider state in ams v1.
+	$parsedArmId = Get-ParsedArmId $amsv1ArmId
+	[string]$monitorName = $parsedArmId.amsResourceName;
+	[string]$resourceGroupName = $parsedArmId.amsResourceGroup;
+	[string]$subscriptionId = $parsedArmId.subscriptionId;
+	
+	# set context.
+	Set-AzContext -SubscriptionId $subscriptionId -TenantId $tenantId;
+	$logger.LogInfo("Checking provisioning state for provider $providerName in AMS v1.");
+	[string]$v1State = GetAmsV1ProviderStatus -subscriptionId $subscriptionId -resourceGroup $resourceGroupName -monitorName $MonitorName -providerName $providerName -logger $logger;
+	$logger.LogInfo("Provisioning State in AMS v1 : $v1State");
+	return $v1State;
 }
 
 <#
@@ -208,6 +257,18 @@ logger object.
 MigrateHanaProvider -secretName $secret.name -secretValue $secret -logger $logger
 #>
 function MigrateHanaProvider([string]$secretName, $secretValue, $logger) {
+	
+	[string]$providerType = $($secretValue.type);
+	[string]$providerName = $($secretValue.name);
+
+	$v1HanaState = GetProviderV1ProvisioningState -providerName $providerName -logger $logger;
+	if($v1HanaState[1] -like "Failed") {
+		$logger.LogInfo("Provider $providerName is in Failed state in AMS v1. Skipping migration.");
+		return @{
+			provisiongState = "Skipped"
+		}
+	}
+
 	$parsedArmId = Get-ParsedArmId $amsv2ArmId
 
 	[string]$monitorName = $parsedArmId.amsResourceName;
@@ -216,9 +277,6 @@ function MigrateHanaProvider([string]$secretName, $secretValue, $logger) {
 	# set context.
 	Set-AzContext -SubscriptionId $subscriptionId -TenantId $tenantId;
 
-	[string]$providerType = $($secretValue.type);
-	[string]$providerName = $($secretValue.name)
-	Write-Host "Provider Name is $($secretValue.name)";
 	$providerProperties = $($secretValue.properties)
 	$requestObj = @{
 		Name = $providerName
@@ -241,15 +299,19 @@ function MigrateHanaProvider([string]$secretName, $secretValue, $logger) {
 	$provisioningState = $getResponse.provisiongState;
 	$logger.LogInfo("Current Provisioning State : $provisioningState")
 
+	# if the Provider already exists then proceed with no action.
 	if($provisioningState -eq "Succeeded") {
 		$logger.LogInfo("Provider $providerName already exists..");
 		Continue;
 	}
-	elseif ($provisioningState -eq "Failed") {
-		$managedKvName = GetAmsV2ManagedKv -subscriptionId $subscriptionId -resourceGroup $resourceGroupName -monitorName $monitorName -logger $logger;
-		$funcName = GetAmsV2ManagedFunc -subscriptionId $subscriptionId -resourceGroup $resourceGroupName -monitorName $monitorName -providerType $providerType -logger $logger;
-		# TODO : code to generate the key name 
-		# DeleteAndPurgeSecretFromKeyVault -keyVaultName "dummyName" -secretKey "dummyKey"
+
+	# trying to delete secret
+	# this step is to take care of deleted Successful providers and Failed providers with secret not purged.
+	[string]$managedKvName = GetAmsV2ManagedKv -subscriptionId $subscriptionId -resourceGroup $resourceGroupName -monitorName $monitorName -logger $logger;
+	[string]$funcName = GetAmsV2ManagedFunc -subscriptionId $subscriptionId -resourceGroup $resourceGroupName -monitorName $monitorName -providerType $providerType -logger $logger;
+	if($funcName.Length -gt 0 -and $managedKvName.Length -gt 0) {
+		[string]$managedSecretName = "saphana-provider-" + $funcName + "-instance-" + $providerName;
+		DeleteAndPurgeSecretFromKeyVault -keyVaultName $managedKvName -secretKey $managedSecretName -logger $logger;
 	}
 
 	# call the put provider method.
@@ -261,13 +323,14 @@ function MigrateHanaProvider([string]$secretName, $secretValue, $logger) {
 	# default providioning state is accepted, we will keep checking till is changes.
 	$provisioningState = "Accepted";
 		
-	while ($checks -le 15 -and ($provisioningState -like "Accepted" -or $provisioningState -like "Creating")) {
-		Start-Sleep -s 20
+	while ($checks -le 30 -and ($provisioningState -like "Accepted" -or $provisioningState -like "Creating")) {
+
+		Start-Sleep -s 30
 		$getResponse = GetAmsV2ProviderStatus -subscriptionId $subscriptionId -resourceGroup $resourceGroupName -monitorName $monitorName -providerName $providerName -logger $logger;
 		$provisioningState = $getResponse.provisiongState;
 		$checks += 1;
-		$logger.LogInfo("Current Provisioning State : $provisioningState")
-		$logger.LogInfo("Checked the status of Put Provider Call ($checks/15) times.")
+		$logger.LogInfo("Current Provisioning State : $provisioningState");
+		$logger.LogInfo("Checked the status of Put Provider Call ($checks/30) times");
 	}
 
 	if($provisioningState -eq "Succeeded") {
@@ -282,6 +345,22 @@ function MigrateHanaProvider([string]$secretName, $secretValue, $logger) {
 	}
 }
 
+<#
+.SYNOPSIS
+Function to create SAP Netweaver request body for PUT calls.
+
+.PARAMETER providerProperties
+SAP Netweaver Provider Properties (hostname, instance number etc.).
+
+.PARAMETER metadata
+Provider metadata (SID)
+
+.PARAMETER hostfile
+host file entries for SAP Netweaver Provider.
+
+.EXAMPLE
+SetNetweaverRequestBody -providerProperties $providerProperties -metadata $metadata -hostfile $hostfile
+#>
 function SetNetweaverRequestBody($providerProperties, $metadata, $hostfile)
 {
 	$requestObj = @{
@@ -298,8 +377,7 @@ function SetNetweaverRequestBody($providerProperties, $metadata, $hostfile)
 			}
 		}
 	}
-    $str = ConvertTo-Json $requestObj -Depth 5
-    Write-Host "netweaverrrrrrrrrrrrrrrrrrr  " $str
+
 	return $requestObj
 }
 
@@ -323,6 +401,17 @@ logger object.
 MigrateNetWeaverProvider -secretName $secret.name -secretValue $secret -logger $logger
 #>
 function MigrateNetWeaverProvider([string]$secretName, $secretValue, $hostfile, $logger) {
+	
+	[string]$providerType = $($secretValue.type);
+	[string]$providerName = $($secretValue.name);
+
+	$v1HanaState = GetProviderV1ProvisioningState -providerName $providerName -logger $logger;
+	if($v1HanaState[1] -like "Failed") {
+		$logger.LogInfo("Provider $providerName is in Failed state in AMS v1. Skipping migration.");
+		return @{
+			provisiongState = "Skipped"
+		}
+	}
 	$parsedArmId = Get-ParsedArmId $amsv2ArmId
 
 	[string]$monitorName = $parsedArmId.amsResourceName;
@@ -331,9 +420,6 @@ function MigrateNetWeaverProvider([string]$secretName, $secretValue, $hostfile, 
 	# set context.
 	Set-AzContext -SubscriptionId $subscriptionId -TenantId $tenantId;
 
-	[string]$providerType = $($secretValue.type);
-	[string]$providerName = $($secretValue.name)
-	Write-Host "Provider Name is $($secretValue.name)";
 	$providerProperties = $($secretValue.properties)
     $metadata = $($secretValue.metadata)
 	$requestObj = SetNetweaverRequestBody -providerProperties $providerProperties -metadata $metadata -hostfile $hostfile
@@ -343,15 +429,19 @@ function MigrateNetWeaverProvider([string]$secretName, $secretValue, $hostfile, 
 	$provisioningState = $getResponse.provisiongState;
 	$logger.LogInfo("Current Provisioning State : $provisioningState")
 
+	# if the Provider already exists then proceed with no action.
 	if($provisioningState -eq "Succeeded") {
 		$logger.LogInfo("Provider $providerName already exists..");
 		Continue;
 	}
-	elseif ($provisioningState -eq "Failed") {
-		$managedKvName = GetAmsV2ManagedKv -subscriptionId $subscriptionId -resourceGroup $resourceGroupName -monitorName $monitorName -logger $logger;
-		$funcName = GetAmsV2ManagedFunc -subscriptionId $subscriptionId -resourceGroup $resourceGroupName -monitorName $monitorName -providerType $providerType -logger $logger;
-		# TODO : code to generate the key name 
-		# DeleteAndPurgeSecretFromKeyVault -keyVaultName "dummyName" -secretKey "dummyKey"
+
+	# trying to delete secret
+	# this step is to take care of deleted Successful providers and Failed providers with secret not purged.
+	[string]$managedKvName = GetAmsV2ManagedKv -subscriptionId $subscriptionId -resourceGroup $resourceGroupName -monitorName $monitorName -logger $logger;
+	[string]$funcName = GetAmsV2ManagedFunc -subscriptionId $subscriptionId -resourceGroup $resourceGroupName -monitorName $monitorName -providerType $providerType -logger $logger;
+	if(($funcName -ne "") -and ($managedKvName -ne "")) {
+		[string]$managedSecretName = "saphana-provider-" + $funcName + "-instance-" + $providerName;
+		DeleteAndPurgeSecretFromKeyVault -keyVaultName $managedKvName -secretKey $managedSecretName -logger $logger;
 	}
 
 	# call the put provider method.
@@ -363,13 +453,13 @@ function MigrateNetWeaverProvider([string]$secretName, $secretValue, $hostfile, 
 	# default providioning state is accepted, we will keep checking till is changes.
 	$provisioningState = "Accepted";
 		
-	while ($checks -le 15 -and ($provisioningState -like "Accepted" -or $provisioningState -like "Creating")) {
-		Start-Sleep -s 20
+	while ($checks -le 30 -and ($provisioningState -like "Accepted" -or $provisioningState -like "Creating")) {
+		Start-Sleep -s 30
 		$getResponse = GetAmsV2ProviderStatus -subscriptionId $subscriptionId -resourceGroup $resourceGroupName -monitorName $monitorName -providerName $providerName -logger $logger;
 		$provisioningState = $getResponse.provisiongState;
 		$checks += 1;
-		$logger.LogInfo("Current Provisioning State : $provisioningState")
-		$logger.LogInfo("Checked the status of Put Provider Call ($checks/15) times.")
+		$logger.LogInfo("Current Provisioning State : $provisioningState");
+		$logger.LogInfo("Checked the status of Put Provider Call ($checks/30) times");
 	}
 
 	if($provisioningState -eq "Succeeded") {

--- a/MigrationScript/Migration.ps1
+++ b/MigrationScript/Migration.ps1
@@ -6,10 +6,10 @@
 [string]$tenantId = "72f988bf-86f1-41af-91ab-2d7cd011db47",
 
 #[Parameter(Mandatory=$true)]
-[string]$providerType = "saphana",
+[string]$providerType = "sapnetweaver",
 
 #[Parameter(Mandatory=$true)]
-[string]$amsv1ArmId = "/subscriptions/49d64d54-e966-4c46-a868-1999802b762c/resourceGroups/rg-ams-migration-test/providers/Microsoft.HanaOnAzure/sapMonitors/ams-v1-migration-hana",
+[string]$amsv1ArmId = "/subscriptions/49d64d54-e966-4c46-a868-1999802b762c/resourceGroups/rg-ams-migration-test/providers/Microsoft.HanaOnAzure/sapMonitors/ams-v1-migration-netweaver",
 
 #[Parameter(Mandatory=$true)]
 [string]$amsv2ArmId = "/subscriptions/49d64d54-e966-4c46-a868-1999802b762c/resourceGroups/rg-ams-migration-test/providers/Microsoft.Workloads/monitors/ams-migration-test"
@@ -363,13 +363,19 @@ SetNetweaverRequestBody -providerProperties $providerProperties -metadata $metad
 #>
 function SetNetweaverRequestBody($providerProperties, $metadata, $hostfile)
 {
+	$subDomain = ""
+	if($($providerProperties.sapSubdomain) -notlike $null)
+	{
+		$subDomain = "." + $($providerProperties.sapSubdomain)
+	}
+
 	$requestObj = @{
 		Name = $providerName
 		body = @{
 			properties = @{
 				providerSettings = @{
 					providerType = $netweaverProviderType
-					sapHostname = $($providerProperties.sapHostName)
+					sapHostname = $($providerProperties.sapHostName) + $subDomain
 					sapSid = $($metadata.sapSid)
 					sapInstanceNr = $($providerProperties.sapInstanceNr).ToString()
 					sapHostFileEntries = $hostfile

--- a/MigrationScript/Migration.ps1
+++ b/MigrationScript/Migration.ps1
@@ -1,18 +1,12 @@
 ﻿param(
 #[Parameter(Mandatory=$true)]
-[string]$subscriptionId = "49d64d54-e966-4c46-a868-1999802b762c",
+[string]$providerType = $null,
 
 #[Parameter(Mandatory=$true)]
-[string]$tenantId = "72f988bf-86f1-41af-91ab-2d7cd011db47",
+[string]$amsv1ArmId = "<amsv1_arm_id>",
 
 #[Parameter(Mandatory=$true)]
-[string]$providerType = "sapnetweaver",
-
-#[Parameter(Mandatory=$true)]
-[string]$amsv1ArmId = "/subscriptions/49d64d54-e966-4c46-a868-1999802b762c/resourceGroups/rg-ams-migration-test/providers/Microsoft.HanaOnAzure/sapMonitors/ams-v1-migration-netweaver",
-
-#[Parameter(Mandatory=$true)]
-[string]$amsv2ArmId = "/subscriptions/49d64d54-e966-4c46-a868-1999802b762c/resourceGroups/rg-ams-migration-test/providers/Microsoft.Workloads/monitors/ams-migration-test"
+[string]$amsv2ArmId = "<amsv2_arm_id>"
 )
 
 # ########### Header ###########

--- a/MigrationScript/Migration.ps1
+++ b/MigrationScript/Migration.ps1
@@ -160,7 +160,8 @@ function Main
 
 				if(!$hashTable.ContainsKey($secret.name))
 				{
-					$hashTable.Add($secret.name, @())
+					$hashTable.Add($secret.name, @());
+					$logger.LogInfo("Provider $($secret.name) not found in hosts file. Setting empty hostfile entry[]");
 				}
 
 				$netweaverMigrationResult = MigrateNetWeaverProvider -secretName $secret.name -secretValue $secret -hostfile $hashTable[$secret.name] -logger $logger

--- a/MigrationScript/Migration.ps1
+++ b/MigrationScript/Migration.ps1
@@ -157,6 +157,12 @@ function Main
 				$hashTable = ParseSapNetWeaverHostfile -fileName "hosts.json" -logger $logger;
 
                 $logger.LogInfoObject("Trying to migrate SapNetWeaver Provider", $secret.name);
+
+				if(!$hashTable.ContainsKey($secret.name))
+				{
+					$hashTable.Add($secret.name, @())
+				}
+
 				$netweaverMigrationResult = MigrateNetWeaverProvider -secretName $secret.name -secretValue $secret -hostfile $hashTable[$secret.name] -logger $logger
 
 				$requestNet = @{

--- a/MigrationScript/ProviderTypePrompt.ps1
+++ b/MigrationScript/ProviderTypePrompt.ps1
@@ -23,3 +23,23 @@
 
     return $providerType
 }
+
+function Get-ProviderSapSid([string]$providerName, $logger)
+{
+    Add-Type -AssemblyName PresentationCore,PresentationFramework
+    # $MessageIcon = [System.Windows.MessageBoxImage]::Warning
+    [void][Reflection.Assembly]::LoadWithPartialName('Microsoft.VisualBasic')
+ 
+	[string]$sapSid = "";
+	while ($sapSid.Length -lt 3) {
+		[string]$messageTitle = 'Enter SAP SID'
+		[string]$dialogContent = "SAP SID property not found for provider $providerName." + "`n`n" +
+		"Please enter a 3 letter SAP SID for provider $providerName"
+		$sapSid = [Microsoft.VisualBasic.Interaction]::InputBox($dialogContent, $messageTitle);
+	}
+	$sapSid = $sapSid.ToUpper();
+	$sapSid = $sapSid.Substring(0,3);
+    $logger.LogInfo("For provider $providerName, User entered SAP SID : $($sapSid)");
+    return $sapSid;
+}
+

--- a/MigrationScript/UtilityFunctions.ps1
+++ b/MigrationScript/UtilityFunctions.ps1
@@ -16,6 +16,7 @@ Set-CurrentContext -subscriptionId $subscriptionId -tenantId $tenantId -logger $
 #>
 function Set-CurrentContext($subscriptionId, $tenantId, $logger)
 {
+	$logger.LogInfo("Setting context for the current user with SubscriptionId $subscriptionId and tenant $tenantId");
     Get-AzSubscription -SubscriptionId $subscriptionId -TenantId $tenantId | Set-AzContext
 }
 
@@ -43,6 +44,17 @@ function Get-ParsedArmId($armId)
     return $parsedInput
 }
 
+<#
+.SYNOPSIS
+Function to get the SAP Netweaver Provider List.
+Prints a summary of all the SAP Netweaver Providers in Azure AMS v2.
+
+.PARAMETER sapNetWeaverTransformedList
+List of SAP Netweaver Providers.
+
+.EXAMPLE
+Get-SapNetWeaverProvidersList $sapNetWeaverTransformedList
+#>
 function Get-SapNetWeaverProvidersList($sapNetWeaverTransformedList)
 {
     $width = 25
@@ -71,6 +83,17 @@ function Get-SapNetWeaverProvidersList($sapNetWeaverTransformedList)
     Write-Host "|-------------------------------------------------------------------|"
 }
 
+<#
+.SYNOPSIS
+Function to get the SAP Provider list which are not supported.
+Prints a summary of all the unsupported SAP Providers in Azure AMS v2.
+
+.PARAMETER unsupportedProviderList
+List of SAP Providers which are not supported currently.
+
+.EXAMPLE
+Get-UnsupportedProvidersList $unsupportedProviderList
+#>
 function Get-UnsupportedProvidersList($unsupportedProviderList)
 {
     $width = 25
@@ -99,6 +122,17 @@ function Get-UnsupportedProvidersList($unsupportedProviderList)
     Write-Host "|-------------------------------------------------------------------|"
 }
 
+<#
+.SYNOPSIS
+Function to get the SAP Hana Provider List.
+Prints a summary of all the SAP Hana Providers in Azure AMS v2.
+
+.PARAMETER saphanaTransformedList
+List of SAP HANA Providers.
+
+.EXAMPLE
+ Get-SapHanaProvidersList $saphanaTransformedList
+#>
 function Get-SapHanaProvidersList($saphanaTransformedList)
 {
     $width = 25
@@ -128,6 +162,13 @@ function Get-SapHanaProvidersList($saphanaTransformedList)
 }
 
 # Install module pre-requisites
+<#
+.SYNOPSIS
+Function to Install azure module pre-requisites
+
+.EXAMPLE
+InstallModules
+#>
 function InstallModules()
 {
     try {
@@ -163,8 +204,24 @@ function InstallModules()
     }
 }
 
-function ParseSapNetWeaverHostfile($fileName)
+<#
+.SYNOPSIS
+Function to Parse all the SAP Netweaver host file entries.
+
+.PARAMETER fileName
+Path of the 
+.PARAMETER logger
+Parameter description
+
+.EXAMPLE
+An example
+
+.NOTES
+General notes
+#>
+function ParseSapNetWeaverHostfile($fileName, $logger)
 {
+	$logger.LogInfo("Parsing host.json file.");
     $fileName = "hosts.json"
 
     $logFilePath = Join-Path $PSScriptRoot "\$fileName"
@@ -176,10 +233,8 @@ function ParseSapNetWeaverHostfile($fileName)
 
     foreach($i in $content)
     {
-        Write-Host $i.providerName
-        Write-Host $i.sapHostFileEntries.Count
-        Write-Host "---------------------------------"
-        
+        $logger.LogInfo("Found Provider $($i.providerName)");
+        $logger.LogInfo("with host file entries : $($i.sapHostFileEntries)");
         $hashTable.add($i.providerName,$i.sapHostFileEntries)
     }
     return $hashTable


### PR DESCRIPTION
- Add code to purge secrets from keyvault.
- Handle purge if function app does not exists
- If ams v1 has provisioning state  failed then don't create provider in ams v2 
- Check for RFC Netweaver Provider in SAP Netweaver Provider and skip migration. 
- Move migration logs to new folder.
- Increase Time limit to track provider status to 15 minutes.