### PR TITLE
Alert Migration for different LAWS

### DIFF
--- a/src/AlertsHelperFunctions.ps1
+++ b/src/AlertsHelperFunctions.ps1
@@ -1,0 +1,109 @@
+<#
+.SYNOPSIS
+Function to get alerts inside a Resource Group.
+
+.PARAMETER SubscriptionId
+the SubscriptionId.
+
+.PARAMETER ResourceGroupName
+the ResourceGroupName.
+
+.PARAMETER logger
+logger object.
+
+.EXAMPLE
+. $PSScriptRoot\ConsoleLogger.ps1
+$logger = New-Object ConsoleLogger
+$x = GetAlerts -SubscriptionId $subscriptionId -ResourceGroupName $rgName -logger $logger;
+#>
+function GetAlerts([string]$SubscriptionId, [string]$ResourceGroupName, $logger) {
+	
+	# get token for the current user.
+	$rawToken = Get-AzAccessToken -ResourceTypeName Arm;
+    $armToken = $rawToken.Token;
+    $headers = @{
+        "Content-Type" = "application/json"
+        "Authorization" = "Bearer $armToken"
+    }
+
+	[string]$apiVersion = "2021-08-01";
+	[string]$url = "https://management.azure.com/";
+	[string]$subscriptionParams = "subscriptions/" + $SubscriptionId;
+	[string]$rgParams = "/resourceGroups/" + $ResourceGroupName;
+	[string]$providerParams = "/providers/Microsoft.Insights/scheduledQueryRules?api-version=$apiVersion";
+	$url = $url + $subscriptionParams + $rgParams + $providerParams;
+
+	try
+    {
+        $response = Invoke-RestMethod -Method 'get' -Uri $url -Headers $headers;
+    }
+    catch
+    {
+        $GetAlertsErrorMsg = $_.ErrorDetails.ToString();
+		$logger.LogInfo("GetAlerts failed with error : ($($GetAlertsErrorMsg)))");
+    }
+
+	return @{
+		Response = $response
+		Error = $GetAlertsErrorMsg
+	};
+}
+
+<#
+.SYNOPSIS
+Function to create an alert in a resource group in LAWS.
+
+
+.PARAMETER SubscriptionId
+the SubscriptionId.
+
+.PARAMETER ResourceGroupName
+the ResourceGroupName.
+
+.PARAMETER alertName
+name of the alert.
+
+.PARAMETER request
+request object.
+
+.PARAMETER logger
+logger object.
+
+.EXAMPLE
+An example
+#>
+function PutAlert([string]$subscriptionId, [string]$resourceGroup, [string]$alertName, $request, $logger) {
+	$rawToken = Get-AzAccessToken -ResourceTypeName Arm;
+    $armToken = $rawToken.Token;
+
+	$headers = @{
+        "Content-Type" = "application/json"
+        "Authorization" = "Bearer $armToken"
+    };
+
+    $bodyStr = $request.body | ConvertTo-Json -Depth 5;
+	[string]$apiVersion = "2021-08-01";
+	[string]$url = "https://management.azure.com/";
+	[string]$subscriptionParams = "subscriptions/" + $SubscriptionId;
+	[string]$rgParams = "/resourceGroups/" + $ResourceGroupName;
+	[string]$providerParams = "/providers/Microsoft.Insights/scheduledQueryRules/$alertName?api-version=$apiVersion";
+	$url = $url + $subscriptionParams + $rgParams + $providerParams;
+
+	$url = $url + $subscriptionParams + $rgParams + $providerParams;
+
+	$logger.LogInfo("Making Put Alert call with $url")
+	try
+    {
+        $response = Invoke-RestMethod -Method 'Put' -Uri $url -Headers $headers -Body $bodyStr
+    }
+    catch
+    {
+        $putAlertErrorMsg = $_.ErrorDetails | ConvertTo-Json -Depth 10;
+		$logger.LogInfo("PutAlert failed with error: ($($putAlertErrorMsg))");
+    }
+
+	return @{
+		Response = $response
+		Error = $putAlertErrorMsg
+	}
+}

--- a/src/AlertsHelperFunctions.ps1
+++ b/src/AlertsHelperFunctions.ps1
@@ -136,7 +136,14 @@ function MigrateLawsAlerts($LawsDetails, $providerType, $logger) {
             }
             else
             {
-                $logger.LogInfo("Unsupported Alert Migration for - $($alertName))");
+                if($alert1.tags.'alert-template-id'.Contains("sapnetweaver") -or $alert1.tags.'alert-template-id'.Contains("saphana"))
+                {
+                    $logger.LogInfo("No Alert Migration for - $($alertName))");
+                }
+                else
+                {
+                    $logger.LogInfo("Unsupported Alert Migration for - $($alertName))");
+                }
             }
         }
     }

--- a/src/AmsOperationsHelper.ps1
+++ b/src/AmsOperationsHelper.ps1
@@ -142,6 +142,59 @@ function GetAmsV2ProviderStatus([string]$subscriptionId, [string]$resourceGroup,
 
 <#
 .SYNOPSIS
+Function to get the AMSv2 LAWS Arm ID.
+
+.PARAMETER subscriptionId
+SubscriptionId of the AMS v2 Monitor.
+
+.PARAMETER resourceGroup
+Resource Group Name of the AMS v2 Monitor.
+
+.PARAMETER monitorName
+AMS v2 Monitor Name.
+
+.PARAMETER logger
+logger object. 
+
+.EXAMPLE
+. $PSScriptRoot\ConsoleLogger.ps1
+$logger = New-Object ConsoleLogger
+GetAmsV2LawsArmId -subscriptionId $subscriptionId -resourceGroup $resourceGroupName -monitorName $monitorName -logger $logger;
+#>
+function GetAmsV2LawsArmId([string]$subscriptionId, [string]$resourceGroup, [string]$monitorName, $logger)
+{
+    $rawToken = Get-AzAccessToken -ResourceTypeName Arm
+    $armToken = $rawToken.Token
+	$v2ApiVersion = "2021-12-01-preview";
+
+    $headers = @{
+        "Content-Type" = "application/json"
+        "Authorization" = "Bearer $armToken"
+    }
+
+    [string]$url = "https://management.azure.com/";
+	[string]$subscriptionParams = "subscriptions/" + $subscriptionId;
+	[string]$rgParams = "/resourceGroups/" + $resourceGroup;
+	[string]$providerParams = "/providers/Microsoft.Workloads/monitors/" + $monitorName + "?api-version=" + $v2ApiVersion;
+	$url = $url + $subscriptionParams + $rgParams + $providerParams;
+	$logger.LogInfo("Making Get Provider call with $url")
+    
+	try
+    {
+        $response = Invoke-RestMethod -Method 'get' -Uri $url -Headers $headers;
+		$lawsArmId = $response.properties.logAnalyticsWorkspaceArmId
+    }
+    catch
+    {
+        $GetProviderErrorMsg = $_.ErrorDetails.ToString();
+		$logger.LogInfo("GetAmsV2ProviderStatus : $($GetProviderErrorMsg)");
+    }
+
+	return $lawsArmId;
+}
+
+<#
+.SYNOPSIS
 Function to get the AMS v2 Monitor Properties.
 
 .PARAMETER subscriptionId
@@ -288,6 +341,57 @@ function GetAmsV2ManagedFunc([string]$subscriptionId, [string]$resourceGroup, [s
 	return $managedFuncName;
 }
 
+<#
+.SYNOPSIS
+Function to get the AMSv1 LAWS Arm ID.
+
+.PARAMETER subscriptionId
+SubscriptionId of the AMS v1 Monitor.
+
+.PARAMETER resourceGroup
+Resource Group Name of the AMS v1 Monitor.
+
+.PARAMETER monitorName
+AMS v1 Monitor Name.
+
+.PARAMETER logger
+logger object. 
+
+.EXAMPLE
+. $PSScriptRoot\ConsoleLogger.ps1
+$logger = New-Object ConsoleLogger
+GetAmsV1LawsArmId -subscriptionId $subscriptionId -resourceGroup $resourceGroupName -monitorName $monitorName -logger $logger;
+#>
+function GetAmsV1LawsArmId([string]$subscriptionId, [string]$resourceGroup, [string]$monitorName, $logger)
+{
+    $rawToken = Get-AzAccessToken -ResourceTypeName Arm
+    $armToken = $rawToken.Token
+	$v2ApiVersion = "2020-02-07-preview";
+
+    $headers = @{
+        "Content-Type" = "application/json"
+        "Authorization" = "Bearer $armToken"
+    }
+
+    [string]$url = $url = "https://management.azure.com/"
+	[string]$subscriptionParams = "subscriptions/" + $subscriptionId;
+	[string]$rgParams = "/resourceGroups/" + $resourceGroup;
+	[string]$providerParams = "/providers/Microsoft.HanaOnAzure/sapMonitors/" + $monitorName + "?api-version=" + $v2ApiVersion;
+	$url = $url + $subscriptionParams + $rgParams + $providerParams;
+	$logger.LogInfo("Making Get Provider call with $url");
+    
+	try
+    {
+        $response = Invoke-RestMethod -Method 'get' -Uri $url -Headers $headers;
+		[string]$lawsArmId = $response.properties.logAnalyticsWorkspaceArmId;
+    }
+    catch
+    {
+        $GetProviderErrorMsg = $_.ErrorDetails.ToString();
+		$logger.LogInfo("GetAmsV1ProviderStatus : $($GetProviderErrorMsg)");
+    }
+	return $lawsArmId;
+}
 
 <#
 .SYNOPSIS

--- a/src/AmsOperationsHelper.ps1
+++ b/src/AmsOperationsHelper.ps1
@@ -373,7 +373,7 @@ function GetAmsV1LawsArmId([string]$subscriptionId, [string]$resourceGroup, [str
         "Authorization" = "Bearer $armToken"
     }
 
-    [string]$url = $url = "https://management.azure.com/"
+    [string]$url = "https://management.azure.com/"
 	[string]$subscriptionParams = "subscriptions/" + $subscriptionId;
 	[string]$rgParams = "/resourceGroups/" + $resourceGroup;
 	[string]$providerParams = "/providers/Microsoft.HanaOnAzure/sapMonitors/" + $monitorName + "?api-version=" + $v2ApiVersion;

--- a/src/AmsOperationsHelper.ps1
+++ b/src/AmsOperationsHelper.ps1
@@ -187,7 +187,7 @@ function GetAmsV2LawsArmId([string]$subscriptionId, [string]$resourceGroup, [str
     catch
     {
         $GetProviderErrorMsg = $_.ErrorDetails.ToString();
-		$logger.LogInfo("GetAmsV2ProviderStatus : $($GetProviderErrorMsg)");
+		$logger.LogInfo("GetAmsV2LawsStatus : $($GetProviderErrorMsg)");
     }
 
 	return $lawsArmId;
@@ -388,7 +388,7 @@ function GetAmsV1LawsArmId([string]$subscriptionId, [string]$resourceGroup, [str
     catch
     {
         $GetProviderErrorMsg = $_.ErrorDetails.ToString();
-		$logger.LogInfo("GetAmsV1ProviderStatus : $($GetProviderErrorMsg)");
+		$logger.LogInfo("GetAmsV1LawsStatus : $($GetProviderErrorMsg)");
     }
 	return $lawsArmId;
 }

--- a/src/KeyvaultHelperFunctions.ps1
+++ b/src/KeyvaultHelperFunctions.ps1
@@ -109,7 +109,6 @@ DeleteAndPurgeSecretFromKeyVault -keyVaultName $keyVaultName -secretKey $name -l
 #>
 function DeleteAndPurgeSecretFromKeyVault([string]$keyVaultName, [string]$secretKey, $logger) {
 	try {
-		# Add-KeyVaultRoleAssignment -keyVaultName $keyVaultName -logger $logger;
 		Remove-AzKeyVaultSecret -VaultName $keyVaultName -Name $secretKey -PassThru -Force -ErrorAction SilentlyContinue;
 		$logger.LogInfo("Deleted Secret $secretKey from Keyvault $keyVaultName, Sleeping for 15s");
 		Start-Sleep -s 15

--- a/src/KeyvaultHelperFunctions.ps1
+++ b/src/KeyvaultHelperFunctions.ps1
@@ -109,7 +109,7 @@ DeleteAndPurgeSecretFromKeyVault -keyVaultName $keyVaultName -secretKey $name -l
 #>
 function DeleteAndPurgeSecretFromKeyVault([string]$keyVaultName, [string]$secretKey, $logger) {
 	try {
-		Add-KeyVaultRoleAssignment -keyVaultName $keyVaultName -logger $logger;
+		# Add-KeyVaultRoleAssignment -keyVaultName $keyVaultName -logger $logger;
 		Remove-AzKeyVaultSecret -VaultName $keyVaultName -Name $secretKey -PassThru -Force -ErrorAction SilentlyContinue;
 		$logger.LogInfo("Deleted Secret $secretKey from Keyvault $keyVaultName, Sleeping for 15s");
 		Start-Sleep -s 15

--- a/src/Migration.ps1
+++ b/src/Migration.ps1
@@ -3,10 +3,10 @@
 [string]$providerType = "saphana",
 
 #[Parameter(Mandatory=$true)]
-[string]$amsv1ArmId = "/subscriptions/49d64d54-e966-4c46-a868-1999802b762c/resourceGroups/rg-ams-migration-test/providers/Microsoft.HanaOnAzure/sapMonitors/ams-v1-migration-hana",
+[string]$amsv1ArmId = "/subscriptions/49d64d54-e966-4c46-a868-1999802b762c/resourceGroups/rg-ams-migration-test/providers/Microsoft.HanaOnAzure/sapMonitors/ams-v1-migration-full",
 
 #[Parameter(Mandatory=$true)]
-[string]$amsv2ArmId = "/subscriptions/49d64d54-e966-4c46-a868-1999802b762c/resourceGroups/suha-0802-rg1/providers/Microsoft.Workloads/monitors/migrationv2-0303-ams1"
+[string]$amsv2ArmId = "/subscriptions/49d64d54-e966-4c46-a868-1999802b762c/resourceGroups/rg-ams-migration-test/providers/Microsoft.Workloads/monitors/ams-migration-test"
 )
 
 # ########### Header ###########
@@ -17,6 +17,7 @@
 . $PSScriptRoot\ProviderTypePrompt.ps1
 . $PSScriptRoot\AmsOperationsHelper.ps1
 . $PSScriptRoot\Constants.ps1
+. $PSScriptRoot\AlertsHelperFunctions.ps1
 # #############################
 
 <#
@@ -83,8 +84,21 @@ function Main
     $unsupportedProviderList = New-Object System.Collections.ArrayList
 	$emptyNwList = New-Object System.Collections.ArrayList
 	$isFirstNwProvider = $true
+	
+	# set context in AMS v2 Monitor's Subscription.
+	$parsedArmId = Get-ParsedArmId $amsv2ArmId
+	[string]$monitorName = $parsedArmId.amsResourceName;
+	[string]$resourceGroupName = $parsedArmId.amsResourceGroup;
+	[string]$subscriptionId = $parsedArmId.subscriptionId;
+	# Get AMS v2 Managed Resource Group Name.
+	$response = GetAmsV2MonitorProperties -subscriptionId $subscriptionId -resourceGroup $resourceGroupName -monitorName $monitorName -logger $logger
+	$managedRgName = $response.Response.properties.managedResourceGroupConfiguration.name;
+	$logger.LogInfo("Managed RG Name associated with Monitor : $monitorName is $managedRgName");
+	# Get values for managed keyvault name and function name.
+	[string]$managedKvName = GetAmsV2ManagedKv -subscriptionId $subscriptionId -resourceGroup $resourceGroupName -monitorName $monitorName -managedRgName $managedRgName -logger $logger;
+	Add-KeyVaultRoleAssignment -keyVaultName $managedKvName -logger $logger;
 
-    <#foreach ($i in $listOfSecrets)
+    foreach ($i in $listOfSecrets)
     {
 		
         if($i.Name.Contains('global'))
@@ -220,12 +234,12 @@ function Main
 
     Get-SapHanaProvidersList $saphanaTransformedList
     Get-SapNetWeaverProvidersList $sapNetWeaverTransformedList
-    Get-UnsupportedProvidersList $unsupportedProviderList#>
+    Get-UnsupportedProvidersList $unsupportedProviderList
 
 	$compareLaws = Get-CompareLaws -amsv1ArmId $amsv1ArmId -amsv2ArmId $amsv2ArmId -logger $logger
 	$isMigrateAlerts = "";
 
-	if($compareLaws.isEqual)
+	if($compareLaws.isEqual -eq $true)
 	{
 		$logger.LogInfo("AMSv1 and AMSv2 LAWS - $($compareLaws.amsv2LawsId) are equal..");
 	}
@@ -235,8 +249,12 @@ function Main
 		[string]$dialogContent = "Please select an action for Alert Migration.";
 		Write-Host $dialogContent;
 		while (($isMigrateAlerts -ne "yes") -and ($isMigrateAlerts -ne "no")) {
-			$isMigrateAlerts = Read-Host -Prompt "Do you wish to Migrate Alerts?";
+			$isMigrateAlerts = Read-Host -Prompt "Do you wish to Migrate Alerts? (Y/N)";
 		}
+	}
+
+	if($isMigrateAlerts -like "Y") {
+		MigrateLAWSAlerts -LawsDetails $compareLaws -logger $logger;
 	}
 
 	$logFolderPath = Join-Path $PSScriptRoot "\LogFiles\$shortDate"
@@ -263,28 +281,24 @@ function Get-CompareLaws([string]$amsv1ArmId, [string]$amsv2ArmId, $logger)
 	$logger.LogInfo("Comapring AMSv1 and AMSv2 LAWS..");
 	$parsedv1ArmId = Get-ParsedArmId $amsv1ArmId
 	$parsedv2ArmId = Get-ParsedArmId $amsv2ArmId
-
+	$isEqual = $false;
 	[string]$amsv1LawsId = GetAmsV1LawsArmId -subscriptionId $parsedv1ArmId.subscriptionId -resourceGroup $parsedv1ArmId.amsResourceGroup -monitorName $parsedv1ArmId.amsResourceName -logger $logger;
 	[string]$amsv2LawsId = GetAmsV2LawsArmId -subscriptionId $parsedv2ArmId.subscriptionId -resourceGroup $parsedv2ArmId.amsResourceGroup -monitorName $parsedv2ArmId.amsResourceName -logger $logger;
 
 	if($amsv1LawsId -eq $amsv2LawsId)
 	{
-		$laws = @{
-			isEqual = $true
-			amsv1LawsId = $amsv1LawsId
-			amsv2LawsId = $amsv2LawsId
-		}
-		return $laws;
+		$isEqual = $true;
 	}
-	else
-	{
-		$laws = @{
-			isEqual = $false
-			amsv1LawsId = $amsv1LawsId
-			amsv2LawsId = $amsv2LawsId
-		}
-		return $laws;
-	}
+
+	$laws = @{
+		isEqual = $isEqual
+		amsv1LawsId = $amsv1LawsId
+		amsv2LawsId = $amsv2LawsId
+		amsv1ArmID = $amsv1ArmId
+		amsv2ArmId = $amsv2ArmId
+	};
+	return $laws;
+
 }
 
 <#

--- a/src/Migration.ps1
+++ b/src/Migration.ps1
@@ -1,12 +1,12 @@
 ﻿param(
 #[Parameter(Mandatory=$true)]
-[string]$providerType = "saphana",
+[string]$providerType = $null,
 
 #[Parameter(Mandatory=$true)]
-[string]$amsv1ArmId = "/subscriptions/49d64d54-e966-4c46-a868-1999802b762c/resourceGroups/rg-ams-migration-test/providers/Microsoft.HanaOnAzure/sapMonitors/ams-v1-migration-full",
+[string]$amsv1ArmId = "<amsv1-arm-id>",
 
 #[Parameter(Mandatory=$true)]
-[string]$amsv2ArmId = "/subscriptions/49d64d54-e966-4c46-a868-1999802b762c/resourceGroups/rg-ams-migration-test/providers/Microsoft.Workloads/monitors/ams-migration-test"
+[string]$amsv2ArmId = "<amsv2-arm-id>"
 )
 
 # ########### Header ###########
@@ -58,7 +58,7 @@ function Main
 	}
 
     $logger.LogInfo("Please select an account to connect to Azure Portal...")
-    #Connect-AzAccount -UseDeviceAuthentication;
+    Connect-AzAccount -UseDeviceAuthentication;
 
     $parsedv1ArmId = Get-ParsedArmId $amsv1ArmId
     $logger.LogInfoObject("Parsed AMSv1 ARM id - ", $parsedv1ArmId)

--- a/src/Migration.ps1
+++ b/src/Migration.ps1
@@ -246,7 +246,7 @@ function Main
 	}
 
 	if($isMigrateAlerts -like "yes") {
-		MigrateLAWSAlerts -LawsDetails $compareLaws -logger $logger;
+		MigrateLAWSAlerts -LawsDetails $compareLaws -providerType $providerType -logger $logger;
 	}
 
 	$logFolderPath = Join-Path $PSScriptRoot "\LogFiles\$shortDate"

--- a/src/Migration.ps1
+++ b/src/Migration.ps1
@@ -228,14 +228,6 @@ function Main
     	$logger.LogInfoObject("Not Migrated AMSv1 Unsupported Provider list - ", $unsupportedProviderList);
 	}
 
-	$logger.LogInfo("----------- Finished migration to AMSv2 --------------");
-	$logger.LogInfo("--------------- Migration Completed ------------------");
-    Stop-Transcript
-
-    Get-SapHanaProvidersList $saphanaTransformedList
-    Get-SapNetWeaverProvidersList $sapNetWeaverTransformedList
-    Get-UnsupportedProvidersList $unsupportedProviderList
-
 	$compareLaws = Get-CompareLaws -amsv1ArmId $amsv1ArmId -amsv2ArmId $amsv2ArmId -logger $logger
 	$isMigrateAlerts = "";
 
@@ -249,11 +241,11 @@ function Main
 		[string]$dialogContent = "Please select an action for Alert Migration.";
 		Write-Host $dialogContent;
 		while (($isMigrateAlerts -ne "yes") -and ($isMigrateAlerts -ne "no")) {
-			$isMigrateAlerts = Read-Host -Prompt "Do you wish to Migrate Alerts? (Y/N)";
+			$isMigrateAlerts = Read-Host -Prompt "Do you wish to Migrate Alerts? (yes/no)";
 		}
 	}
 
-	if($isMigrateAlerts -like "Y") {
+	if($isMigrateAlerts -like "yes") {
 		MigrateLAWSAlerts -LawsDetails $compareLaws -logger $logger;
 	}
 
@@ -261,6 +253,14 @@ function Main
 	Write-Host "If you are using Cloud Shell, run the below command to download the log file";
 	Write-Host -ForegroundColor Yellow $logFolderPath;
 	Write-Host -ForegroundColor Yellow "download $fileName.txt";
+
+	$logger.LogInfo("----------- Finished migration to AMSv2 --------------");
+	$logger.LogInfo("--------------- Migration Completed ------------------");
+    Stop-Transcript
+
+    Get-SapHanaProvidersList $saphanaTransformedList
+    Get-SapNetWeaverProvidersList $sapNetWeaverTransformedList
+    Get-UnsupportedProvidersList $unsupportedProviderList
 }
 
 <#

--- a/src/Migration.ps1
+++ b/src/Migration.ps1
@@ -248,6 +248,10 @@ function Main
 	if($isMigrateAlerts -like "yes") {
 		MigrateLAWSAlerts -LawsDetails $compareLaws -providerType $providerType -logger $logger;
 	}
+	else
+	{
+		$logger.LogInfo("Not migrating Alerts since you entered No");
+	}
 
 	$logFolderPath = Join-Path $PSScriptRoot "\LogFiles\$shortDate"
 	Write-Host "If you are using Cloud Shell, run the below command to download the log file";


### PR DESCRIPTION
1. This PR contains alert migration when the LAWS of AMSv1 and v2 are different.
2. We get the list of Alerts using the 2018 API version of scheduled queries as AMSv1 had their queries written using the same version.